### PR TITLE
Modified include syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Based on Tim's feedback, instead of using `<xsdl:include/>` as originally propos
       <Script>
         <Transforms>
           <EspRequest>
-            <xsdl:include file="service-scripts.xml"/>
+            <include file="service-scripts.xml"/>
 		<!-- 
 			By default all the transforms defined in service-scripts.xml
 			are included here in this element
@@ -58,8 +58,8 @@ or just include some by name:
       <Script>
         <Transforms>
           <EspRequest>
-            <xsdl:include file="service-scripts.xml" transform="GenericOutOfBand"/>
-            <xsdl:include file="service-scripts.xml" transform="UserOutOfBand"/>
+            <include file="service-scripts.xml" transform="GenericOutOfBand"/>
+            <include file="service-scripts.xml" transform="UserOutOfBand"/>
           </EspRequest>
         </Transforms>
       </Script>

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Based on Tim's feedback, instead of using `<xsdl:include/>` as originally propos
 		<Definition>
 			<Script>
 				<Transforms>
-					<xsdl:EspRequest>
+					<EspRequest>
 						<xsdl:include-from file="service-scripts.xml"/>
 						<!-- 
 							By default all the transforms defined in service-scripts.xml
 							are included here in this element
 						-->
-					</xsdl:EspRequest>
+					</EspRequest>
 				</Transforms>
 			</Script>
 		</Definition>	
@@ -57,10 +57,10 @@ or just include some by name:
 		<Definition>
 			<Script>
 				<Transforms>
-					<xsdl:EspRequest>
+					<EspRequest>
  					  <xsdl:include file="service-scripts.xml" transform="GenericOutOfBand"/>
  					  <xsdl:include file="service-scripts.xml" transform="UserOutOfBand"/>
-					</xsdl:EspRequest>
+					</EspRequest>
 				</Transforms>
 			</Script>
 		</Definition>	

--- a/README.md
+++ b/README.md
@@ -35,50 +35,50 @@ We'll implement the tool in several incremental phases to get some basic functio
  
 Based on Tim's feedback, instead of using `<xsdl:include/>` as originally proposed, change it so that it can be used to either include _all_ the scripts in the referenced file:
 
-	<Binding>
-		<Definition>
-			<Script>
-				<Transforms>
-					<EspRequest>
-						<xsdl:include-from file="service-scripts.xml"/>
-						<!-- 
-							By default all the transforms defined in service-scripts.xml
-							are included here in this element
-						-->
-					</EspRequest>
-				</Transforms>
-			</Script>
-		</Definition>	
-	</Binding>
+  <Binding>
+    <Definition>
+      <Script>
+        <Transforms>
+          <EspRequest>
+            <xsdl:include file="service-scripts.xml"/>
+		<!-- 
+			By default all the transforms defined in service-scripts.xml
+			are included here in this element
+		-->
+          </EspRequest>
+        </Transforms>
+      </Script>
+    </Definition>	
+  </Binding>
 
 or just include some by name:
 
-	<Binding>
-		<Definition>
-			<Script>
-				<Transforms>
-					<EspRequest>
- 					  <xsdl:include file="service-scripts.xml" transform="GenericOutOfBand"/>
- 					  <xsdl:include file="service-scripts.xml" transform="UserOutOfBand"/>
-					</EspRequest>
-				</Transforms>
-			</Script>
-		</Definition>	
-	</Binding>
+  <Binding>
+    <Definition>
+      <Script>
+        <Transforms>
+          <EspRequest>
+            <xsdl:include file="service-scripts.xml" transform="GenericOutOfBand"/>
+            <xsdl:include file="service-scripts.xml" transform="UserOutOfBand"/>
+          </EspRequest>
+        </Transforms>
+      </Script>
+    </Definition>	
+  </Binding>
 
 or as a list of names:
 
-	<Binding>
-		<Definition>
-			<Script>
-				<Transforms>
-					<EspRequest>
- 					  <xsdl:include file="service-scripts.xml" transforms="GenericOutOfBand,UserOutOfBand"/>
-					</EspRequest>
-				</Transforms>
-			</Script>
-		</Definition>	
-	</Binding>
+  <Binding>
+    <Definition>
+      <Script>
+        <Transforms>
+          <EspRequest>
+            <xsdl:include file="service-scripts.xml" transforms="GenericOutOfBand,UserOutOfBand"/>
+          </EspRequest>
+        </Transforms>
+      </Script>
+    </Definition>	
+  </Binding>
 
 This way you can organize scripts in 'shared' files where different subsets of transforms are used by a wide variety of different bindings. Also you can put all the transforms you'd need for a given service or method in a single file and automatically include 
 

--- a/README.md
+++ b/README.md
@@ -66,20 +66,6 @@ or just include some by name:
     </Definition>	
   </Binding>
 
-or as a list of names:
-
-  <Binding>
-    <Definition>
-      <Script>
-        <Transforms>
-          <EspRequest>
-            <xsdl:include file="service-scripts.xml" transforms="GenericOutOfBand,UserOutOfBand"/>
-          </EspRequest>
-        </Transforms>
-      </Script>
-    </Definition>	
-  </Binding>
-
 This way you can organize scripts in 'shared' files where different subsets of transforms are used by a wide variety of different bindings. Also you can put all the transforms you'd need for a given service or method in a single file and automatically include 
 
 ### Deployment Variables

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Based on Tim's feedback, instead of using `<xsdl:include/>` as originally propos
 			<Script>
 				<Transforms>
 					<xsdl:EspRequest>
-						<xsdl:include-from file="service-scripts.xml" all="true"/>
+						<xsdl:include-from file="service-scripts.xml"/>
 						<!-- 
-								All the transforms defined in service-scripts.xml
-								are included here in this element
+							By default all the transforms defined in service-scripts.xml
+							are included here in this element
 						-->
 					</xsdl:EspRequest>
 				</Transforms>
@@ -58,10 +58,8 @@ or just include some by name:
 			<Script>
 				<Transforms>
 					<xsdl:EspRequest>
-						<xsdl:include-from file="service-scripts.xml" all="false">
-							<xsdl:include transform="GenericOutOfBand"/>
-							<xsdl:include transform="UserOutOfBand"/>
-						</xsdl:include-from>
+ 					  <xsdl:include file="service-scripts.xml" transform="GenericOutOfBand"/>
+ 					  <xsdl:include file="service-scripts.xml" transform="UserOutOfBand"/>
 					</xsdl:EspRequest>
 				</Transforms>
 			</Script>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ or just include some by name:
 		</Definition>	
 	</Binding>
 
+or as a list of names:
+
+	<Binding>
+		<Definition>
+			<Script>
+				<Transforms>
+					<EspRequest>
+ 					  <xsdl:include file="service-scripts.xml" transforms="GenericOutOfBand,UserOutOfBand"/>
+					</EspRequest>
+				</Transforms>
+			</Script>
+		</Definition>	
+	</Binding>
+
 This way you can organize scripts in 'shared' files where different subsets of transforms are used by a wide variety of different bindings. Also you can put all the transforms you'd need for a given service or method in a single file and automatically include 
 
 ### Deployment Variables


### PR DESCRIPTION
We can optimize the iinclude statments internally, but I think it's less complicated not to nest them.. default should be to include all transforms, otherwise you can name the transform, we could also support a list.